### PR TITLE
Fix enum field association for global enums

### DIFF
--- a/src/doxygen.cpp
+++ b/src/doxygen.cpp
@@ -7231,7 +7231,8 @@ static void addEnumValuesToEnums(const Entry *root)
                         if (!fmd->isStrongEnumValue()) // only non strong enum values can be globally added
                         {
                           const FileDef *ffd=fmd->getFileDef();
-                          if (ffd==fd) // enum value has file scope
+                          const FileDef *mfd=md->getFileDef();
+                          if (ffd==mfd) // enum value has file scope
                           {
                             md->insertEnumField(fmd);
                             fmd->setEnumScope(md);


### PR DESCRIPTION
Make sure that the enum and contained enum fields originate from the same file.  This fixes the following test case:

File "a.c":

/**
 * @file *
 * @brief a.c */

/**
 * @brief E in a.c */ enum E {
  /**
   * @brief A in a.c */ A };

File "b.c":

/**
 * @file *
 * @brief b.c */

/**
 * @brief E in b.c */ enum E {
  /**
   * @brief B in b.c */ B };

Without this fix, each enum E documentation contained the enum fields A and B.